### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
-[vamsikrishnak123/php-helloworld](https://github.com/vamsikrishnak123/php-helloworld.git) |  | []() | 
+[vamsikrishnak123/jx-canary](https://github.com/vamsikrishnak123/jx-canary.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
-[vamsikrishnak123/jx-canary1](https://github.com/vamsikrishnak123/jx-canary1.git) |  | []() | 
+[vamsikrishnak123/jx-canary2](https://github.com/vamsikrishnak123/jx-canary2.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
+[vamsikrishnak123/php-helloworld](https://github.com/vamsikrishnak123/php-helloworld.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
-[vamsikrishnak123/jx-canary2](https://github.com/vamsikrishnak123/jx-canary2.git) |  | []() | 
+[vamsikrishnak123/jx-canary3](https://github.com/vamsikrishnak123/jx-canary3.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
-[vamsikrishnak123/jx-canary3](https://github.com/vamsikrishnak123/jx-canary3.git) |  | []() | 
+[vamsikrishnak123/jx-canary4](https://github.com/vamsikrishnak123/jx-canary4.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vamsikrishnak123/testxyz](https://github.com/vamsikrishnak123/testxyz.git) |  | []() | 
-[vamsikrishnak123/jx-canary](https://github.com/vamsikrishnak123/jx-canary.git) |  | []() | 
+[vamsikrishnak123/jx-canary1](https://github.com/vamsikrishnak123/jx-canary1.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vamsikrishnak123
-  repo: php-helloworld
-  url: https://github.com/vamsikrishnak123/php-helloworld.git
+  repo: jx-canary
+  url: https://github.com/vamsikrishnak123/jx-canary.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vamsikrishnak123
-  repo: jx-canary1
-  url: https://github.com/vamsikrishnak123/jx-canary1.git
+  repo: jx-canary2
+  url: https://github.com/vamsikrishnak123/jx-canary2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vamsikrishnak123
-  repo: jx-canary3
-  url: https://github.com/vamsikrishnak123/jx-canary3.git
+  repo: jx-canary4
+  url: https://github.com/vamsikrishnak123/jx-canary4.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vamsikrishnak123
-  repo: jx-canary2
-  url: https://github.com/vamsikrishnak123/jx-canary2.git
+  repo: jx-canary3
+  url: https://github.com/vamsikrishnak123/jx-canary3.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/vamsikrishnak123/testxyz.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: vamsikrishnak123
+  repo: php-helloworld
+  url: https://github.com/vamsikrishnak123/php-helloworld.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vamsikrishnak123
-  repo: jx-canary
-  url: https://github.com/vamsikrishnak123/jx-canary.git
+  repo: jx-canary1
+  url: https://github.com/vamsikrishnak123/jx-canary1.git
   version: ""
   versionURL: ""

--- a/repositories/templates/vamsikrishnak123-jx-canary-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-jx-canary-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: jx-canary
+  name: vamsikrishnak123-jx-canary
+spec:
+  description: Imported application for vamsikrishnak123/jx-canary
+  httpCloneURL: https://github.com/vamsikrishnak123/jx-canary.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-canary
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/jx-canary.git

--- a/repositories/templates/vamsikrishnak123-jx-canary1-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-jx-canary1-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: jx-canary1
+  name: vamsikrishnak123-jx-canary1
+spec:
+  description: Imported application for vamsikrishnak123/jx-canary1
+  httpCloneURL: https://github.com/vamsikrishnak123/jx-canary1.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-canary1
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/jx-canary1.git

--- a/repositories/templates/vamsikrishnak123-jx-canary2-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-jx-canary2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: jx-canary2
+  name: vamsikrishnak123-jx-canary2
+spec:
+  description: Imported application for vamsikrishnak123/jx-canary2
+  httpCloneURL: https://github.com/vamsikrishnak123/jx-canary2.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-canary2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/jx-canary2.git

--- a/repositories/templates/vamsikrishnak123-jx-canary3-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-jx-canary3-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: jx-canary3
+  name: vamsikrishnak123-jx-canary3
+spec:
+  description: Imported application for vamsikrishnak123/jx-canary3
+  httpCloneURL: https://github.com/vamsikrishnak123/jx-canary3.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-canary3
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/jx-canary3.git

--- a/repositories/templates/vamsikrishnak123-jx-canary4-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-jx-canary4-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: jx-canary4
+  name: vamsikrishnak123-jx-canary4
+spec:
+  description: Imported application for vamsikrishnak123/jx-canary4
+  httpCloneURL: https://github.com/vamsikrishnak123/jx-canary4.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-canary4
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/jx-canary4.git

--- a/repositories/templates/vamsikrishnak123-php-helloworld-sr.yaml
+++ b/repositories/templates/vamsikrishnak123-php-helloworld-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vamsikrishnak123
+    provider: github
+    repository: php-helloworld
+  name: vamsikrishnak123-php-helloworld
+spec:
+  description: Imported application for vamsikrishnak123/php-helloworld
+  httpCloneURL: https://github.com/vamsikrishnak123/php-helloworld.git
+  org: vamsikrishnak123
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: php-helloworld
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vamsikrishnak123/php-helloworld.git


### PR DESCRIPTION
Update [vamsikrishnak123/jx-canary4](https://github.com/vamsikrishnak123/jx-canary4.git) 

Command run was `jx create quickstart --filter golang-http --name jx-canary4`
<hr />

Update [vamsikrishnak123/jx-canary3](https://github.com/vamsikrishnak123/jx-canary3.git) 

Command run was `jx create quickstart --filter golang-http --name jx-canary3`
<hr />

Update [vamsikrishnak123/jx-canary2](https://github.com/vamsikrishnak123/jx-canary2.git) 

Command run was `jx create quickstart --filter golang-http --name jx-canary2`
<hr />

Update [vamsikrishnak123/jx-canary1](https://github.com/vamsikrishnak123/jx-canary1.git) 

Command run was `jx create quickstart --filter golang-http --name jx-canary1`
<hr />

Update [vamsikrishnak123/jx-canary](https://github.com/vamsikrishnak123/jx-canary.git) 

Command run was `jx create quickstart --filter golang-http --name jx-canary`
<hr />

Update [vamsikrishnak123/php-helloworld](https://github.com/vamsikrishnak123/php-helloworld.git) 

Command run was `jx create quickstart`